### PR TITLE
Use verbose mode during install/remove

### DIFF
--- a/lib/pkgsrc.sh
+++ b/lib/pkgsrc.sh
@@ -7,7 +7,7 @@
 #
 # A simple expressive shortcut to install a pkgsrc package via pkgin
 nos_install() {
-  nos_run_process "Installing packages" "pkgin -y in $(echo $@)"
+  nos_run_process "Installing packages" "pkgin -yV in $(echo $@)"
   # run ldconfig to update cache
   nos_run_process "ldconfig" "sudo ldconfig"
 }
@@ -18,7 +18,7 @@ nos_install() {
 #
 # A simple expressive shortcut to uninstall a pkgsrc package via pkgin
 nos_uninstall() {
-  nos_run_process "Uninstalling packages" "pkgin -y rm $(echo $@)"
+  nos_run_process "Uninstalling packages" "pkgin -yV rm $(echo $@)"
 # run ldconfig to to update cache
   nos_run_process "ldconfig" "sudo ldconfig"
 }


### PR DESCRIPTION
Instead of forcing users into `--debug` mode to `cat /data/var/db/pkgin/pkg_install-err.log`, let's tell `pkgin` to combine the log output with the rest of stderr/stdout, so that it's visible inline when we display the error output.

I'd love to add a flag that allows packages to be downgraded, without also forcing _every_ package to be reinstalled from scratch, but alas, `pkgin` doesn't currently have such an option. Several of the package issues we're seeing during the rebuild are because `pkgin` won't downgrade already-installed packages to the latest versions still registered on the pkgsrc repo, so being able to enable downgrades would fix that, and we'd be able to revoke packages as needed without causing breakage for users.

Of course, the migration to the system's own package manager will bypass that, too, so this change is really the only useful one to make at the moment.